### PR TITLE
busybox install instead of loop.

### DIFF
--- a/tarmaker-ubuntu/Dockerfile
+++ b/tarmaker-ubuntu/Dockerfile
@@ -11,7 +11,7 @@ RUN echo root:x:0: > etc/group
 RUN ln -s lib lib64
 RUN ln -s bin sbin
 RUN cp /bin/busybox bin
-RUN for X in $(busybox --list) ; do ln -s busybox bin/$X ; done
+RUN busybox --install -s bin
 RUN bash -c "cp /lib/x86_64-linux-gnu/lib{c,m,dl,rt,nsl,nss_*,pthread,resolv}.so.* lib"
 RUN cp /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 lib
 RUN tar cf /rootfs.tar .


### PR DESCRIPTION
Busybox bootstraps itself, no need for a loop.
