### PR TITLE
Move up to buildroot 2014.11 and fix IPv6 enablement properly

### DIFF
--- a/tarmaker-buildroot/Dockerfile
+++ b/tarmaker-buildroot/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:14.04
 # This will make it easier to upgrade to the next version of buildroot.
 # You might have to also update the busybox version at the end of this file!
-ENV BUILDROOT_VERSION 2014.02
+ENV BUILDROOT_VERSION 2014.11
 # This will get rid of a build warning related to 'tput'.
 ENV TERM dumb
 RUN apt-get update -q
@@ -12,7 +12,7 @@ RUN which python || ln /usr/bin/python3 /usr/bin/python
 RUN echo progress = dot:mega > /.wgetrc
 RUN wget http://buildroot.uclibc.org/downloads/buildroot-$BUILDROOT_VERSION.tar.gz
 # Check that we got the right tarball (update this when upgrading buildroot!)
-RUN echo "8d30803d27cd88fb27ec87b003a4de37  buildroot-$BUILDROOT_VERSION.tar.gz" > buildroot.md5
+RUN echo "dcfcaa315469e7d0bfdfe59ac216f808  buildroot-$BUILDROOT_VERSION.tar.gz" > buildroot.md5
 RUN md5sum --check buildroot.md5
 RUN tar -zxf buildroot-$BUILDROOT_VERSION.tar.gz
 # This symlink is because WORKDIR doesn't expand $VARS.
@@ -23,9 +23,7 @@ RUN sed -i "s/BR2_i386=y/# BR2_i386 is not set/" .config
 RUN for CFGVAR in \
     BR2_x86_64 \
     BR2_TOOLCHAIN_BUILDROOT_LARGEFILE \
-# Disable IPv6 for now, because some programs (like nc) will not try to connect
-# over IPv4 if something resolves to at least a AAAA record.
-#   BR2_TOOLCHAIN_BUILDROOT_INET_IPV6 \
+    BR2_TOOLCHAIN_BUILDROOT_INET_IPV6 \
     BR2_TOOLCHAIN_BUILDROOT_WCHAR \
     BR2_PACKAGE_BRIDGE_UTILS \
     BR2_PACKAGE_IPROUTE2 \
@@ -36,9 +34,15 @@ RUN for CFGVAR in \
     CONFIG_NC_SERVER \
     CONFIG_NC_EXTRA \
     CONFIG_BRCTL \
+    CONFIG_PING6 \
+    CONFIG_FEATURE_IPV6 \
+    CONFIG_FEATURE_IFUPDOWN_IPV6 \
+# The below feature will prefer an IPv4 address over IPv6 from DNS to handle the
+# original problem regarding nc using the AAAA record if it exists
+    CONFIG_FEATURE_PREFER_IPV4_ADDRESS \
     CONFIG_FEATURE_BRCTL_FANCY \
     CONFIG_FEATURE_BRCTL_SHOW \
-    ; do sed -i "s/# $CFGVAR is not set/$CFGVAR=y/" package/busybox/busybox-1.22.x.config ; done
+    ; do sed -i "s/# $CFGVAR is not set/$CFGVAR=y/" package/busybox/busybox.config ; done
 RUN make olddefconfig
 RUN make
 RUN ln -s /buildroot/output/images/rootfs.tar /rootfs.tar


### PR DESCRIPTION
This solves the segfault of `ip addr show` in busybox, as well as
solves the original issue around `nc` using IPv6 addresses by using the
busybox feature PREFER_IPV4.

Docker-DCO-1.1-Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com> (github: estesp)